### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/modal.test.tsx
+++ b/__tests__/modal.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Modal } from "../components/ui/modal";
+
+describe("Modal component", () => {
+  it("renders when open and handles close", async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal isOpen={true} onClose={onClose} title="Test">
+        <div>content</div>
+      </Modal>
+    );
+
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.getByText("content")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not render when closed", () => {
+    const { container } = render(
+      <Modal isOpen={false} onClose={() => {}} title="Hi">
+        <div>hidden</div>
+      </Modal>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/__tests__/utils.extra.test.ts
+++ b/__tests__/utils.extra.test.ts
@@ -1,0 +1,75 @@
+import {
+  formatDateTime,
+  formatRelativeDate,
+  formatMonthYear,
+  getTransactionTypeColor,
+  getCategoryColor,
+  storage,
+  debounce,
+  buildUrl,
+} from "../lib/utils";
+
+describe("Additional utils", () => {
+  it("formats date and time correctly", () => {
+    const date = new Date("2024-05-15T10:30:00Z");
+    expect(formatDateTime(date)).toMatch(/15\/05\/2024.*10:30/);
+  });
+
+  it("formats relative date", () => {
+    const date = new Date();
+    expect(formatRelativeDate(date)).toContain("há");
+  });
+
+  it("formats month and year", () => {
+    const date = new Date("2023-02-01T00:00:00Z");
+    expect(formatMonthYear(date)).toMatch(/fevereiro 2023/i);
+  });
+
+  it("returns transaction type colors", () => {
+    expect(getTransactionTypeColor("income")).toEqual({
+      bg: "bg-green-100",
+      text: "text-green-600",
+      border: "border-green-200",
+    });
+    expect(getTransactionTypeColor("expense")).toEqual({
+      bg: "bg-red-100",
+      text: "text-red-600",
+      border: "border-red-200",
+    });
+  });
+
+  it("picks a default category color if none provided", () => {
+    const color = getCategoryColor();
+    expect(typeof color).toBe("string");
+    expect(color.startsWith("#")).toBe(true);
+    expect(color.length).toBe(7);
+  });
+
+  it("handles storage operations", () => {
+    storage.set("key", { a: 1 });
+    expect(storage.get("key")).toEqual({ a: 1 });
+    storage.remove("key");
+    expect(storage.get("key")).toBeNull();
+    storage.set("k2", 2);
+    storage.clear();
+    expect(storage.get("k2")).toBeNull();
+  });
+
+  it("debounces function calls", () => {
+    jest.useFakeTimers();
+    const fn = jest.fn();
+    const debounced = debounce(fn, 200);
+    debounced();
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(250);
+    expect(fn).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it("builds urls with params", () => {
+    const url = buildUrl("/test", { a: 1, b: "x" });
+    expect(url).toContain("a=1");
+    expect(url).toContain("b=x");
+  });
+});

--- a/__tests__/validations.test.ts
+++ b/__tests__/validations.test.ts
@@ -1,0 +1,62 @@
+import {
+  validateLogin,
+  validateRegister,
+  validateTransaction,
+  validateBudget,
+  validateCategory,
+  validateProfile,
+} from "../lib/validations";
+
+describe("Validation Schemas", () => {
+  it("validates login data", () => {
+    const result = validateLogin({ email: "a@b.com", password: "secret" });
+    expect(result.success).toBe(true);
+    const fail = validateLogin({ email: "wrong", password: "123" });
+    expect(fail.success).toBe(false);
+  });
+
+  it("validates register data with mismatched passwords", () => {
+    const res = validateRegister({
+      email: "a@b.com",
+      password: "123456",
+      confirmPassword: "000000",
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("validates transaction data", () => {
+    const ok = validateTransaction({
+      description: "Test",
+      amount: 10,
+      type: "income",
+      category_id: "7b54e3ce-2ce1-4b57-9f92-123456789abc",
+      date: new Date("2020-01-01T00:00:00Z"),
+    });
+    expect(ok.success).toBe(true);
+  });
+
+  it("invalid budget with high amount", () => {
+    const res = validateBudget({
+      name: "Budget",
+      amount: 1000000,
+      category_id: "7b54e3ce-2ce1-4b57-9f92-123456789abc",
+      period: "monthly",
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("category requires hex color", () => {
+    const res = validateCategory({
+      name: "Cat",
+      color: "#ZZZZZZ",
+      icon: "icon",
+      type: "income",
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("profile email is required", () => {
+    const res = validateProfile({ email: "" });
+    expect(res.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for additional utility functions
- test validation schemas
- add modal component tests

## Testing
- `npm test -- --coverage --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_68445b1f9bd88330b8016a0a7fbfe847