### PR TITLE
Fix user search and improve modal layout

### DIFF
--- a/components/forms/transaction-form.tsx
+++ b/components/forms/transaction-form.tsx
@@ -85,8 +85,9 @@ export function TransactionForm({
     >
       <div className="card-glass">
         <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid gap-6 md:grid-cols-2">
           {/* Transaction Type */}
-          <div>
+          <div className="md:col-span-2">
             <label className="block text-sm font-medium text-gray-300 mb-3">
               Transaction Type
             </label>
@@ -326,6 +327,8 @@ export function TransactionForm({
                 </svg>
               </div>
             </div>
+          </div>
+          {/* Close grid */}
           </div>
 
           {/* User Selector for Sharing */}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -64,12 +64,11 @@ export const searchUsers = async (query: string) => {
       return [];
     }
 
-    const { data, error } = await supabase
-      .from("profiles")
-      .select("id, email, full_name")
-      .or(`email.ilike.%${query}%,full_name.ilike.%${query}%`)
-      .neq("id", currentUser.id) // Excluir o usuário atual
-      .limit(10);
+    // Utiliza a stored procedure para respeitar as regras de privacidade
+    const { data, error } = await supabase.rpc("search_users_for_sharing", {
+      search_query: query,
+      current_user_id: currentUser.id,
+    });
 
     if (error) {
       console.log("searchUsers error", error);


### PR DESCRIPTION
## Summary
- make `searchUsers` call stored procedure
- tidy layout of transaction modal with responsive grid

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459e3ff5088330899389629100dda1