### PR TITLE
Fix QueryClient provider usage

### DIFF
--- a/__tests__/dashboardClient.test.tsx
+++ b/__tests__/dashboardClient.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { DashboardClient } from "../app/dashboard/dashboard-client";
+
+jest.mock("../components/forms/transaction-form", () => ({
+  TransactionForm: () => <div data-testid="transaction-form" />,
+}));
+
+jest.mock("../components/dashboard/metrics-cards", () => ({
+  MetricsCards: () => <div data-testid="metrics-cards" />,
+}));
+
+jest.mock("../components/dashboard/transaction-history", () => ({
+  TransactionHistory: () => <div data-testid="transaction-history" />,
+}));
+
+jest.mock("../components/dashboard/monthly-and-yearly-charts", () => ({
+  MonthlyAndYearlyCharts: () => <div data-testid="charts" />,
+}));
+
+jest.mock("../components/profile/user-avatar", () => ({
+  UserAvatar: () => <div data-testid="user-avatar" />,
+}));
+
+jest.mock("../hooks/use-profile", () => ({
+  useProfile: () => ({ profile: null, loading: false }),
+}));
+
+jest.mock("../lib/transactions/service", () => ({
+  TransactionsService: {
+    fetchTransactionsWithShares: jest.fn().mockResolvedValue([]),
+    createSharedTransaction: jest.fn(),
+  },
+}));
+
+jest.mock("../lib/supabase/client", () => ({
+  createClientSupabase: () => ({ from: jest.fn(() => ({ insert: jest.fn() })) }),
+}));
+
+describe("DashboardClient", () => {
+  it("renders wrapped with QueryClientProvider", async () => {
+    render(<DashboardClient user={{ id: "1" } as any} categories={[]} />);
+    expect(await screen.findByTestId("metrics-cards")).toBeInTheDocument();
+  });
+});

--- a/app/dashboard/dashboard-client.tsx
+++ b/app/dashboard/dashboard-client.tsx
@@ -15,7 +15,7 @@ const MonthlyAndYearlyCharts = dynamic<MonthlyAndYearlyChartsProps>(
     ),
   { ssr: false }
 );
-import { useQuery, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useQuery, QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
 import { UserAvatar } from "@/components/profile/user-avatar";
 import { useProfile } from "@/hooks/use-profile";
 import {
@@ -43,9 +43,19 @@ interface FilterState {
   type?: "income" | "expense" | "all";
 }
 
-export function DashboardClient({ user, categories }: DashboardClientProps) {
+export function DashboardClient(props: DashboardClientProps) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <DashboardInner {...props} />
+    </QueryClientProvider>
+  );
+}
+
+function DashboardInner({ user, categories }: DashboardClientProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const queryClient = new QueryClient();
+  const queryClient = useQueryClient();
   const {
     data: transactions = [],
     isLoading,
@@ -175,8 +185,7 @@ export function DashboardClient({ user, categories }: DashboardClientProps) {
   };
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
       {/* Header moderno */}
       <motion.header
         initial={{ opacity: 0, y: -20 }}
@@ -316,6 +325,5 @@ export function DashboardClient({ user, categories }: DashboardClientProps) {
         <div className="absolute bottom-0 right-0 w-96 h-96 bg-purple-500/5 rounded-full blur-3xl"></div>
       </div>
     </div>
-    </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap Dashboard components with QueryClientProvider before using react-query
- test DashboardClient rendering within QueryClientProvider

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685036ecc8f08330bb57d865c6406a25