### PR TITLE
Add shared expenses summary modal

### DIFF
--- a/__tests__/calculateMonthlySplits.test.ts
+++ b/__tests__/calculateMonthlySplits.test.ts
@@ -1,0 +1,55 @@
+import { calculateMonthlySplits } from "../lib/shared-calculations";
+import { TransactionWithShares } from "../types/shared-transactions";
+
+describe("calculateMonthlySplits", () => {
+  const month = new Date("2024-06-05");
+
+  const tx = (
+    id: string,
+    owner: string,
+    amount: number,
+    type: "income" | "expense",
+    shares: any[] = []
+  ): TransactionWithShares => ({
+    id,
+    description: id,
+    amount,
+    type,
+    category_id: "c1",
+    date: "2024-06-10",
+    user_id: owner,
+    is_installment: false,
+    installment_count: null,
+    installment_current: null,
+    installment_group_id: null,
+    created_at: "",
+    updated_at: "",
+    transaction_shares: shares,
+  });
+
+  const share = (uid: string) => ({
+    id: `s-${uid}`,
+    transaction_id: "t",
+    shared_with_user_id: uid,
+    share_type: "equal" as const,
+    share_value: null,
+    status: "accepted" as const,
+    created_at: "",
+    updated_at: "",
+    profiles: { full_name: uid, email: `${uid}@x.com` },
+  });
+
+  it("computes totals and settlements", () => {
+    const data = [
+      tx("t1", "u1", 100, "expense", [share("u2")]),
+      tx("t2", "u2", 60, "expense", [share("u1")]),
+      tx("t3", "u1", 100, "income", [share("u2")]),
+    ];
+    const result = calculateMonthlySplits(data, month);
+    expect(result.userTotals["u1"].expense).toBe(80);
+    expect(result.userTotals["u2"].expense).toBe(80);
+    expect(result.settlements).toEqual([
+      { from: "u1", to: "u2", amount: 30 },
+    ]);
+  });
+});

--- a/__tests__/splitSummaryModal.test.tsx
+++ b/__tests__/splitSummaryModal.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { SplitSummaryModal } from "../components/dashboard/split-summary-modal";
+import { TransactionWithShares } from "../types/shared-transactions";
+
+const baseTx = {
+  category_id: "c1",
+  date: "2024-06-10",
+  is_installment: false,
+  installment_count: null,
+  installment_current: null,
+  installment_group_id: null,
+  created_at: "",
+  updated_at: "",
+};
+
+function tx(owner: string, amount: number, type: "income" | "expense"): TransactionWithShares {
+  return {
+    ...baseTx,
+    id: Math.random().toString(),
+    description: "t",
+    amount,
+    type,
+    user_id: owner,
+    transaction_shares: [],
+  } as TransactionWithShares;
+}
+
+describe("SplitSummaryModal", () => {
+  it("renders totals", () => {
+    const data = [tx("u1", 10, "income")];
+    render(
+      <SplitSummaryModal
+        isOpen={true}
+        onClose={() => {}}
+        transactions={data}
+        month={new Date("2024-06-05")}
+        currentUserId="u1"
+      />
+    );
+    expect(screen.getByText("You")).toBeInTheDocument();
+    expect(screen.getByText(/Income:/)).toBeInTheDocument();
+  });
+});

--- a/app/dashboard/dashboard-client.tsx
+++ b/app/dashboard/dashboard-client.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import { TransactionForm } from "@/components/forms/transaction-form";
 import { MetricsCards } from "@/components/dashboard/metrics-cards";
 import { TransactionHistory } from "@/components/dashboard/transaction-history";
+import { SplitSummaryModal } from "@/components/dashboard/split-summary-modal";
 import dynamic from "next/dynamic";
 import type { MonthlyAndYearlyChartsProps } from "@/components/dashboard/monthly-and-yearly-charts";
 const MonthlyAndYearlyCharts = dynamic<MonthlyAndYearlyChartsProps>(
@@ -23,6 +24,7 @@ import {
   TransactionShareInput,
   TransactionWithCategory,
 } from "@/types/database";
+import { TransactionWithShares } from "@/types/shared-transactions";
 import {
   createClientSupabase,
 } from "@/lib/supabase/client";
@@ -55,6 +57,7 @@ export function DashboardClient(props: DashboardClientProps) {
 
 function DashboardInner({ user, categories }: DashboardClientProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSplitOpen, setIsSplitOpen] = useState(false);
   const queryClient = useQueryClient();
   const {
     data: transactions = [],
@@ -231,6 +234,14 @@ function DashboardInner({ user, categories }: DashboardClientProps) {
                 <Plus className="w-4 h-4" />
                 <span>Nova Transação</span>
               </motion.button>
+              <motion.button
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                onClick={() => setIsSplitOpen(true)}
+                className="bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white px-3 py-2 rounded-xl text-sm font-medium shadow-lg transition-all duration-200"
+              >
+                Calcular Receitas/Despesas Divididas
+              </motion.button>
 
               <div className="flex items-center space-x-2">
                 <motion.button
@@ -317,6 +328,14 @@ function DashboardInner({ user, categories }: DashboardClientProps) {
         onClose={() => setIsModalOpen(false)}
         onSubmit={handleTransactionSubmit}
         categories={categories}
+      />
+
+      <SplitSummaryModal
+        isOpen={isSplitOpen}
+        onClose={() => setIsSplitOpen(false)}
+        transactions={transactions as unknown as TransactionWithShares[]}
+        month={filters.month}
+        currentUserId={user.id}
       />
 
       {/* Background Effects */}

--- a/components/dashboard/split-summary-modal.tsx
+++ b/components/dashboard/split-summary-modal.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Modal } from "@/components/ui/modal";
+import { formatCurrency } from "@/lib/utils";
+import { TransactionWithShares } from "@/types/shared-transactions";
+import { calculateMonthlySplits } from "@/lib/shared-calculations";
+
+interface SplitSummaryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  transactions: TransactionWithShares[];
+  month: Date;
+  currentUserId: string;
+}
+
+export function SplitSummaryModal({
+  isOpen,
+  onClose,
+  transactions,
+  month,
+  currentUserId,
+}: SplitSummaryModalProps) {
+  const { userTotals, settlements } = calculateMonthlySplits(transactions, month);
+
+  const getName = (uid: string) => (uid === currentUserId ? "You" : `User ${uid.slice(0, 4)}`);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Shared Summary" size="lg">
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {Object.entries(userTotals).map(([uid, totals]) => (
+            <div
+              key={uid}
+              className="p-4 rounded-lg bg-gray-800/50 border border-gray-700"
+            >
+              <p className="text-sm text-gray-300 font-medium mb-2">
+                {getName(uid)}
+              </p>
+              <p className="text-xs text-gray-400">
+                Income: <span className="text-white">{formatCurrency(totals.income)}</span>
+              </p>
+              <p className="text-xs text-gray-400">
+                Expenses: <span className="text-white">{formatCurrency(totals.expense)}</span>
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-2">
+          {settlements.length === 0 && (
+            <p className="text-sm text-gray-400">No settlements needed.</p>
+          )}
+          {settlements.map((s) => (
+            <p key={`${s.from}-${s.to}`} className="text-sm text-gray-300">
+              {getName(s.from)} must pay {formatCurrency(s.amount)} to {getName(s.to)}
+            </p>
+          ))}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/lib/shared-calculations.ts
+++ b/lib/shared-calculations.ts
@@ -1,0 +1,81 @@
+import { startOfMonth, endOfMonth } from "date-fns";
+import { TransactionWithShares } from "@/types/shared-transactions";
+
+export interface MonthlySplitResults {
+  userTotals: Record<string, { income: number; expense: number }>;
+  settlements: { from: string; to: string; amount: number }[];
+}
+
+export function calculateMonthlySplits(
+  transactions: TransactionWithShares[],
+  month: Date
+): MonthlySplitResults {
+  const start = startOfMonth(month);
+  const end = endOfMonth(month);
+  const totals: Record<string, { income: number; expense: number }> = {};
+  const balances: Record<string, Record<string, number>> = {};
+
+  const getTotals = (uid: string) => {
+    if (!totals[uid]) {
+      totals[uid] = { income: 0, expense: 0 };
+    }
+    return totals[uid];
+  };
+
+  const incBalance = (from: string, to: string, amount: number) => {
+    if (!balances[from]) {
+      balances[from] = {};
+    }
+    balances[from][to] = (balances[from][to] || 0) + amount;
+  };
+
+  for (const tx of transactions) {
+    const date = new Date(tx.date);
+    if (date < start || date > end) continue;
+
+    const shares = tx.transaction_shares || [];
+    const shareAmounts: { userId: string; amount: number }[] = [];
+    for (const share of shares) {
+      let amount = 0;
+      if (share.share_type === "equal") {
+        amount = tx.amount / (shares.length + 1);
+      } else if (share.share_type === "percentage") {
+        amount = ((share.share_value || 0) / 100) * tx.amount;
+      } else {
+        amount = share.share_value || 0;
+      }
+      shareAmounts.push({ userId: share.shared_with_user_id, amount });
+    }
+    const sharedTotal = shareAmounts.reduce((s, a) => s + a.amount, 0);
+    const ownerAmount = tx.amount - sharedTotal;
+    shareAmounts.push({ userId: tx.user_id, amount: ownerAmount });
+
+    for (const part of shareAmounts) {
+      const t = getTotals(part.userId);
+      if (tx.type === "income") t.income += part.amount;
+      else t.expense += part.amount;
+    }
+
+    for (const part of shareAmounts) {
+      if (part.userId === tx.user_id) continue;
+      if (tx.type === "expense") {
+        incBalance(part.userId, tx.user_id, part.amount);
+      } else {
+        incBalance(tx.user_id, part.userId, part.amount);
+      }
+    }
+  }
+
+  const settlements: { from: string; to: string; amount: number }[] = [];
+  for (const from in balances) {
+    for (const to in balances[from]) {
+      const amount =
+        balances[from][to] - (balances[to]?.[from] ? balances[to][from] : 0);
+      if (amount > 0) {
+        settlements.push({ from, to, amount });
+      }
+    }
+  }
+
+  return { userTotals: totals, settlements };
+}


### PR DESCRIPTION
## Summary
- implement calculation helpers for shared transactions
- add SplitSummaryModal component
- support opening the modal from Dashboard with new button
- compute monthly split totals and settlements
- test calculation logic and modal rendering

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68505325a0b483309ee1d625d9166c5d