### PR TITLE
Fix saving shares for installment transactions

### DIFF
--- a/__tests__/sharedIncomeInstallments.test.ts
+++ b/__tests__/sharedIncomeInstallments.test.ts
@@ -88,6 +88,34 @@ describe("TransactionsService - Shared Income Installments", () => {
     expect(result).toBeDefined();
     expect(supabase.from).toHaveBeenCalled();
     expect(mockInsert).toHaveBeenCalled();
+
+    // Verify shares were created for the first and additional installments
+    expect(mockInsert.mock.calls[1][0]).toEqual([
+      {
+        transaction_id: "transaction-1",
+        shared_with_user_id: "user-1",
+        share_type: "equal",
+        share_value: undefined,
+        status: "accepted",
+      },
+    ]);
+
+    expect(mockInsert.mock.calls[3][0]).toEqual([
+      {
+        transaction_id: "inst-2",
+        shared_with_user_id: "user-1",
+        share_type: "equal",
+        share_value: undefined,
+        status: "accepted",
+      },
+      {
+        transaction_id: "inst-3",
+        shared_with_user_id: "user-1",
+        share_type: "equal",
+        share_value: undefined,
+        status: "accepted",
+      },
+    ]);
   });
 
   it("should handle single transactions correctly", async () => {

--- a/lib/transactions/service.ts
+++ b/lib/transactions/service.ts
@@ -21,9 +21,8 @@ export class TransactionsService {
   ) {
     try {
       // Criar a transação principal
-      const installmentGroupId = transactionData.is_installment
-        ? crypto.randomUUID()
-        : null;
+      const installmentGroupId =
+        transactionData.is_installment ? crypto.randomUUID() : null;
       const firstInstallmentDescription =
         transactionData.is_installment && transactionData.installment_count
           ? `${transactionData.description} (1/${transactionData.installment_count})`
@@ -73,7 +72,6 @@ export class TransactionsService {
         transactionData.installment_count > 1
       ) {
         const installments = [];
-        const installmentGroupId = transaction.installment_group_id;
 
         for (let i = 2; i <= transactionData.installment_count; i++) {
           const installmentDate = new Date(transactionData.date);


### PR DESCRIPTION
## Summary
- ensure shared transactions reuse the same installment group id when creating extra installments
- validate share creation with additional unit tests

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685091979ba083309f5ae3337cc549d7